### PR TITLE
Fix response content-type

### DIFF
--- a/internal/serv/serv.go
+++ b/internal/serv/serv.go
@@ -144,6 +144,7 @@ func routeHandler() (http.Handler, error) {
 
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Server", serverName)
+		w.Header().Set("Content-type", "application/json")
 		mux.ServeHTTP(w, r)
 	}
 


### PR DESCRIPTION
Hi,
server should return Content-type: application/json because this is the only valid response.