### PR TITLE
Add firebase support and jwt audience check

### DIFF
--- a/internal/serv/internal/auth/auth.go
+++ b/internal/serv/internal/auth/auth.go
@@ -32,6 +32,7 @@ type Auth struct {
 		Secret     string
 		PubKeyFile string `mapstructure:"public_key_file"`
 		PubKeyType string `mapstructure:"public_key_type"`
+		Audience   string `mapstructure:"audience"`
 	}
 
 	Header struct {


### PR DESCRIPTION
Adds support for Firebase as a JWT provider.
Requires internet access to retrieve Google's public key, then caches it in memory for a time as determined by the cache-control header in the public key request response.

Additionally, these changes allow an audience configuration option under the jwt settings in the yml file. If such an audience is set, the Audience claim in the supplied token will be compared with it in order for the token validation to succeed.

Firebase support requires the audience option to be set