### PR TITLE
Rate limiter

### DIFF
--- a/config/dev.yml
+++ b/config/dev.yml
@@ -247,3 +247,8 @@ roles:
     tables:
       - name: users
         filters: []
+# rate limit for graph API, This doesn't apply to WebUI and health end points
+# Uncomment
+rate_limiter:
+  rate: 1
+  bucket: 3

--- a/config/dev.yml
+++ b/config/dev.yml
@@ -249,6 +249,6 @@ roles:
         filters: []
 # rate limit for graph API, This doesn't apply to WebUI and health end points
 # Uncomment
-rate_limiter:
-  rate: 1
-  bucket: 3
+# rate_limiter:
+#   rate: 1
+#   bucket: 3

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -74,3 +74,9 @@ database:
 #     exporter: "zipkin"
 #     endpoint: "http://zipkin:9411/api/v2/spans"
 #     sample: 0.6
+
+# rate limit for graph API, This doesn't apply to WebUI and health end points
+# Uncomment
+# rate_limiter:
+#   rate: 1
+#   bucket: 3

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/dop251/goja v0.0.0-20200424152103-d0b8fda54cd0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/garyburd/redigo v1.6.0
+	github.com/go-pkgz/expirable-cache v0.0.3
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/gobuffalo/flect v0.2.1
 	github.com/gosimple/slug v1.9.0
@@ -44,6 +45,7 @@ require (
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3I
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-pkgz/expirable-cache v0.0.3 h1:rTh6qNPp78z0bQE6HDhXBHUwqnV9i09Vm6dksJLXQDc=
+github.com/go-pkgz/expirable-cache v0.0.3/go.mod h1:+IauqN00R2FqNRLCLA+X5YljQJrwB179PfiAoMPlTlQ=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -498,6 +500,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/serv/api.go
+++ b/internal/serv/api.go
@@ -93,6 +93,11 @@ type Serv struct {
 	} `mapstructure:"database"`
 
 	Actions []Action
+
+	RateLimiter struct {
+		Rate   float64
+		Bucket int
+	} `mapstructure:"rate_limiter"`
 }
 
 // Auth struct contains authentication related config values used by the Super Graph service

--- a/internal/serv/config.go
+++ b/internal/serv/config.go
@@ -124,3 +124,8 @@ func (c *Config) relPath(p string) string {
 
 	return path.Join(c.cpath, p)
 }
+
+func (c *Config) rateLimiterEnable() bool {
+	log.Println("Rate", c.RateLimiter.Rate, " Bucket ", c.RateLimiter.Bucket)
+	return c.RateLimiter.Rate > 0 && c.RateLimiter.Bucket > 0
+}

--- a/internal/serv/iplimiter.go
+++ b/internal/serv/iplimiter.go
@@ -1,0 +1,53 @@
+package serv
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	cache "github.com/go-pkgz/expirable-cache"
+	"golang.org/x/time/rate"
+)
+
+var ipCache cache.Cache
+
+func init() {
+	ipCache, _ = cache.NewCache(cache.MaxKeys(10), cache.TTL(time.Minute*5))
+}
+
+func getIPLimiter(ip string) *rate.Limiter {
+
+	v, exists := ipCache.Get(ip)
+	if !exists {
+		limiter := rate.NewLimiter(1, 3)
+		ipCache.Set(ip, limiter, 0)
+		return limiter
+	}
+
+	return v.(*rate.Limiter)
+}
+
+func limit(w http.ResponseWriter, r *http.Request) error {
+	// log.Println("limit")
+
+	// X-Remote-Address is used when super graph configure behind load balancer
+	remoteAddr := r.Header.Get("X-Remote-Address")
+	// log.Println("X-Remote-Address ", remoteAddr)
+	// use request Remote Address if X-Remote-Address not found
+	if len(remoteAddr) == 0 {
+		var err error
+		remoteAddr, _, err = net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			log.Println(err.Error())
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return errors.New("Internal Server Error")
+		}
+	}
+
+	if !getIPLimiter(remoteAddr).Allow() {
+		http.Error(w, "429 Too Many Requests", http.StatusTooManyRequests)
+		return errors.New("StatusTooManyRequests")
+	}
+	return nil
+}

--- a/internal/serv/iplimiter.go
+++ b/internal/serv/iplimiter.go
@@ -35,7 +35,7 @@ func limit(w http.ResponseWriter, r *http.Request) error {
 	remoteAddr := r.Header.Get("X-Remote-Address")
 	// log.Println("X-Remote-Address ", remoteAddr)
 	// use request Remote Address if X-Remote-Address not found
-	if len(remoteAddr) == 0 {
+	if remoteAddr == "" {
 		var err error
 		remoteAddr, _, err = net.SplitHostPort(r.RemoteAddr)
 		if err != nil {

--- a/internal/serv/serv.go
+++ b/internal/serv/serv.go
@@ -165,7 +165,7 @@ func routeHandler() (http.Handler, error) {
 		if conf.rateLimiterEnable() && strings.Contains(r.URL.Path, apiRoute) {
 			err := limit(w, r)
 			if err != nil {
-				log.Println("ERR %s", err)
+				log.Println(err.Error())
 				return
 			}
 		}

--- a/internal/serv/serv.go
+++ b/internal/serv/serv.go
@@ -160,6 +160,15 @@ func routeHandler() (http.Handler, error) {
 
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Server", serverName)
+		// rate limiter only apply if it's enable from configuration and for API route
+		// WebUI and health are excluded from rate limiter
+		if conf.rateLimiterEnable() && strings.Contains(r.URL.Path, apiRoute) {
+			err := limit(w, r)
+			if err != nil {
+				log.Println("ERR %s", err)
+				return
+			}
+		}
 		mux.ServeHTTP(w, r)
 	}
 


### PR DESCRIPTION
Implement rate limiter with https://godoc.org/golang.org/x/time/rate library.

How to enable rate limiter?
Open the Configuration file and uncomment the following settings
```
# rate_limiter:
#   rate: 1
#   bucket: 3
```
How to set Rate and bucket?
Read https://godoc.org/golang.org/x/time/rate

Does the rate limit apply in Web UI?
No, Rate limit does not apply on Web UI and Health endpoints

If Super Graph is configured behind load balancer 
Use header X-Remote-Address to provide original IP. If X-Remote-Address is not found then rate limiter use r.RemoteAddr

Issue: #20