### PR TITLE
Load headers from connection_init ws message and use them for auth

### DIFF
--- a/internal/serv/ws.go
+++ b/internal/serv/ws.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dosco/super-graph/core"
+	"github.com/dosco/super-graph/internal/serv/internal/auth"
 	ws "github.com/gorilla/websocket"
 )
 
@@ -31,6 +32,11 @@ type gqlWsError struct {
 	Payload struct {
 		Error string `json:"error"`
 	} `json:"payload"`
+}
+
+type wsConnInit struct {
+	Type    string            `json:"type,omitempty"`
+	Payload map[string]string `json:"payload,omitempty"`
 }
 
 var upgrader = ws.Upgrader{
@@ -78,12 +84,27 @@ func apiV1Ws(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		if err = json.Unmarshal(b, &msg); err != nil {
+			log.Println(err)
 			continue
 		}
 
 		switch msg.Type {
 		case "connection_init":
-			err = conn.WritePreparedMessage(initMsg)
+			var initReq wsConnInit
+			if err = json.Unmarshal(b, &initReq); err != nil {
+				break
+			}
+			handler, _ := auth.WithAuth(http.HandlerFunc(func (writer http.ResponseWriter, request *http.Request) {
+				ctx = request.Context()
+				err = conn.WritePreparedMessage(initMsg)
+				if err != nil {
+					err = sendError(conn, err)
+				}
+			}), &conf.Auth)
+			for k, v := range initReq.Payload {
+				r.Header.Set(k, v)
+			}
+			handler.ServeHTTP(w, r)
 
 		case "start":
 			if run {
@@ -101,7 +122,7 @@ func apiV1Ws(w http.ResponseWriter, r *http.Request) {
 			run = false
 
 		default:
-			log.Println("subscription: uknown type: ", msg.Type)
+			log.Println("subscription: unknown type: ", msg.Type)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Apollo does not allow custom headers to be sent in the WS Upgrade request. Instead, Apollo allows users to set a  `connectionParams` property when making a request. The headers described in `connectionParams` will be sent as the payload of the `connection_init` message. 

This PR reads in the headers from the `connection_init` message, adds them to the upgrade request, then re-runs the upgrade request through the authentication middleware. Finally, the resulting context (with the `user_id` set) replaces the original upgrade request context.

Now, when the `start` message is triggered, the subscription context should be updated with the `user_id`.