### PR TITLE
Automatic persisted queries

### DIFF
--- a/core/apq_cache.go
+++ b/core/apq_cache.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"crypto/sha1"
+	"time"
+
+	cache "github.com/go-pkgz/expirable-cache"
+)
+
+var apqCache cache.Cache
+
+func init() {
+	apqCache, _ = cache.NewCache(cache.MaxKeys(50), cache.TTL(time.Minute*30))
+}
+
+func setAPQ(hash string, value interface{}) {
+	apqCache.Set(hash, value, 0)
+}
+
+func getAPQ(hash string) (interface{}, bool) {
+	value, exists := apqCache.Get(hash)
+
+	return value, exists
+}
+
+func hashSha1(query string) (string, error) {
+	h := sha1.New()
+	_, err := h.Write([]byte(query))
+	bs := h.Sum(nil)
+	return string(bs), err
+}

--- a/core/apq_cache.go
+++ b/core/apq_cache.go
@@ -1,7 +1,8 @@
 package core
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	cache "github.com/go-pkgz/expirable-cache"
@@ -23,9 +24,7 @@ func getAPQ(hash string) (interface{}, bool) {
 	return value, exists
 }
 
-func hashSha1(query string) (string, error) {
-	h := sha1.New()
-	_, err := h.Write([]byte(query))
-	bs := h.Sum(nil)
-	return string(bs), err
+func hashSha256(query string) string {
+	sha256Bytes := sha256.Sum256([]byte(query))
+	return hex.EncodeToString(sha256Bytes[:])
 }

--- a/core/core.go
+++ b/core/core.go
@@ -160,17 +160,15 @@ func (c *scontext) resolveSQL(query string, vars []byte, role string) (qres, err
 	if err != nil {
 		return res, err
 	}
-	hash, err := hashSha1(query)
-	if err != nil {
-		return res, err
-	}
-	// fmt.Printf("> hash %x\n", hash)
+	hash := hashSha256(query)
+
+	fmt.Printf("> hash %s\n", hash)
 	value, exists := getAPQ(hash)
 	if !exists {
 		if err = c.sg.compileQuery(cq, role); err != nil {
 			return res, err
 		}
-		// fmt.Printf("> setAPQ %+v\n", cq)
+		fmt.Printf("> setAPQ %+v\n", cq)
 		setAPQ(hash, cq)
 	} else {
 		cq = value.(*cquery)


### PR DESCRIPTION
Implement automatic persisted queries with  `github.com/go-pkgz/expirable-cache`.  as of now, cache options are hardcoded (50 queries and 30 min TTL)