### PR TITLE
Do map operations under mutex in Firebase auth

### DIFF
--- a/internal/serv/internal/auth/jwt.go
+++ b/internal/serv/internal/auth/jwt.go
@@ -158,8 +158,9 @@ func firebaseKeyFunction(token *jwt.Token) (interface{}, error) {
 	}
 
 	firebasePublicKeys.lock.RLock()
-	if firebasePublicKeys.Expiration.Before(time.Now()) {
-		firebasePublicKeys.lock.RUnlock()
+	pastExpiration := firebasePublicKeys.Expiration.Before(time.Now())
+	firebasePublicKeys.lock.RUnlock()
+	if pastExpiration {
 		resp, err := http.Get(firebasePKEndpoint)
 
 		if err != nil {

--- a/internal/serv/internal/auth/jwt.go
+++ b/internal/serv/internal/auth/jwt.go
@@ -211,6 +211,7 @@ func firebaseKeyFunction(token *jwt.Token) (interface{}, error) {
 		err = json.Unmarshal(data, &firebasePublicKeys.PublicKeys)
 
 		if err != nil {
+			firebasePublicKeys.lock.Unlock()
 			return nil, &firebaseKeyError{
 				Message: "Error unmarshalling firebase public key json",
 				Err:     err,

--- a/internal/serv/internal/auth/jwt.go
+++ b/internal/serv/internal/auth/jwt.go
@@ -219,8 +219,8 @@ func firebaseKeyFunction(token *jwt.Token) (interface{}, error) {
 		firebasePublicKeys.Expiration = expiration
 	}
 
-	firebasePublicKeys.lock.Lock()
-	defer firebasePublicKeys.lock.Unlock()
+	firebasePublicKeys.lock.RLock()
+	defer firebasePublicKeys.lock.RUnlock()
 	if key, found := firebasePublicKeys.PublicKeys[kid.(string)]; found {
 		k, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
 		return k, err


### PR DESCRIPTION
Previously, the map of public keys in the Firebase authentication code were being concurrently accessed. This PR places both reads and writes behind a single mutex.

I found conflicting information (depending on Go version) about whether it was safe to concurrently read from a map. To be safe, I put the reads behind the mutex in addition to the writes.