### PR TITLE
add POSIX regex support

### DIFF
--- a/core/internal/psql/query.go
+++ b/core/internal/psql/query.go
@@ -729,6 +729,14 @@ func (c *compilerContext) renderOp(schema *sdata.DBSchema, ti sdata.DBTableInfo,
 		c.w.WriteString(`SIMILAR TO`)
 	case qcode.OpNotSimilar:
 		c.w.WriteString(`NOT SIMILAR TO`)
+	case qcode.OpRegex:
+		c.w.WriteString(`~`)
+	case qcode.OpNotRegex:
+		c.w.WriteString(`!~`)
+	case qcode.OpIRegex:
+		c.w.WriteString(`~*`)
+	case qcode.OpNotIRegex:
+		c.w.WriteString(`!~*`)
 	case qcode.OpContains:
 		c.w.WriteString(`@>`)
 	case qcode.OpContainedIn:

--- a/core/internal/qcode/exp.go
+++ b/core/internal/qcode/exp.go
@@ -150,13 +150,25 @@ func newExp(ti sdata.DBTableInfo, st *util.StackInf, av aexp, usePool bool) (*Ex
 		ex.Op = OpILike
 		ex.Val = node.Val
 	case "nilike", "not_ilike":
-		ex.Op = OpILike
+		ex.Op = OpNotILike
 		ex.Val = node.Val
 	case "similar":
 		ex.Op = OpSimilar
 		ex.Val = node.Val
 	case "nsimilar", "not_similar":
 		ex.Op = OpNotSimilar
+		ex.Val = node.Val
+	case "regex":
+		ex.Op = OpRegex
+		ex.Val = node.Val
+	case "nregex", "not_regex":
+		ex.Op = OpNotRegex
+		ex.Val = node.Val
+	case "iregex":
+		ex.Op = OpIRegex
+		ex.Val = node.Val
+	case "niregex", "not_iregex":
+		ex.Op = OpNotIRegex
 		ex.Val = node.Val
 	case "contains":
 		ex.Op = OpContains

--- a/core/internal/qcode/qcode.go
+++ b/core/internal/qcode/qcode.go
@@ -174,6 +174,10 @@ const (
 	OpNotILike
 	OpSimilar
 	OpNotSimilar
+	OpRegex
+	OpNotRegex
+	OpIRegex
+	OpNotIRegex
 	OpContains
 	OpContainedIn
 	OpHasKey

--- a/core/introspec.go
+++ b/core/introspec.go
@@ -447,6 +447,30 @@ func (sg *SuperGraph) initGraphQLEgine() error {
 					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
 				},
 				&schema.InputValue{
+					Name: "regex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
+					Name: "nregex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
+					Name: "not_regex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
+					Name: "iregex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
+					Name: "niregex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
+					Name: "not_iregex",
+					Type: &schema.NonNull{OfType: &schema.TypeName{Name: "String"}},
+				},
+				&schema.InputValue{
 					Name: "has_key",
 					Type: &schema.NonNull{OfType: &schema.TypeName{Name: typeName}},
 				},

--- a/docs/website/docs/graphql.md
+++ b/docs/website/docs/graphql.md
@@ -146,6 +146,10 @@ query {
 | nilike, not_ilike      | name: { nilike "%wOn" }                | Not names ending with 'won' case-insensitive                                                             |
 | similar                | name: { similar: "%(b\|d)%" }          | [Similar Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-SIMILARTO-REGEXP)     |
 | nsimilar, not_similar  | name: { nsimilar: "%(b\|d)%" }         | [Not Similar Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-SIMILARTO-REGEXP) |
+| regex                  | name: { regex: "^([a-zA-Z]+)$" }       | [Regex Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-POSIX-TABLE)            |
+| nregex, not_regex      | name: { nregex: "^([a-zA-Z]+)$" }      | [Regex Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-POSIX-TABLE)            |
+| iregex                 | name: { iregex: "^([a-z]+)$" }         | [Regex Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-POSIX-TABLE)            |
+| niregex, not_iregex    | name: { not_iregex: "^([a-z]+)$" }     | [Regex Docs](https://www.postgresql.org/docs/9/functions-matching.html#FUNCTIONS-POSIX-TABLE)            |
 | has_key                | column: { has_key: 'b' }               | Does JSON column contain this key                                                                        |
 | has_key_any            | column: { has_key_any: [ a, b ] }      | Does JSON column contain any of these keys                                                               |
 | has_key_all            | column: [ a, b ]                       | Does JSON column contain all of this keys                                                                |


### PR DESCRIPTION
Issue #157

This PR adds support for POSIX regular expressions as stated here:
https://www.postgresql.org/docs/9.3/functions-matching.html#FUNCTIONS-POSIX-TABLE

It also fixes a minor bug in `core/internal/qcode/exp.go`, where the operation name was incorrect.